### PR TITLE
Add changes to support responsive layout for supported by section. 

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -85,11 +85,11 @@ h1.text-center:after, h2.text-center:after {
   color: #585858;
 }
 
-.members > div {
-  height: 200px;
+.members > div, .supporters > div {
+  height: 125px;
 }
 
-.members img {
+.members img, .supporters img {
   max-width: 200px;
 }
 

--- a/index.html
+++ b/index.html
@@ -161,7 +161,6 @@
                     </div>
                     <div class="d-flex col-xs-12 col-md-6 col-lg-3 align-items-center justify-content-between flex-column">
                         <img class="img-fluid" src="./assets/images/img-04.jpg"-->
-                    </div>
                 </div>
             </div>
         </div>
@@ -178,7 +177,7 @@
                         <p class="pb-xs-1 pb-lg-3">Our code is available on GitHub and you can help contribute directly through a pull request or issue submission.</p>
                         <a class='btn text-white fold-button' href="https://github.com/aqlaboratory/openfold">OpenFold GitHub</a>
                     </div>
-                    <div class="col-xs-12 col-lg-3 col-xxl-4 pt-3">
+                    <div class="col-xs-12 col-lg-6 col-xxl-4 pt-3">
                         <h4>Join the Consortium</h4>
                         <p class="pb-xs-1 pb-lg-3">All entities are welcome to join the consortium -- corporate, non-profit, and academic. Members contribute financially or technically and play a key role in choosing new directions and high-priority projects. The Consortium also benefits from support provided by different non-member organizations and collaborators with aligned missions. We encourage you to fill out our Google Form to let us know you are interested in supporting the project. After you've submitted your application, someone from the OpenFold Consortium will reach out to chat.</p>
                         <a class='btn text-white fold-button' href="https://forms.gle/KSqgZGinWHbeCLwx6">Join the Consortium</a>
@@ -245,19 +244,20 @@
                    <div class="col-12">
                        <h1 class="text-center">Supported by</h1>
                    </div>
-               <div class="supporters row text-center py-5 d-flex justify-content-center">
+                </div>
+               <div class="supporters row text-center py-5 text-center py-5 d-flex justify-content-center">
                    <div class="d-flex col-xs-12 col-md-6 col-lg-3 align-items-center justify-content-center flex-column">
-                     <a href="https://omsf.io/">
+                     <a class="d-inline-block h-100" href="https://omsf.io/">
                        <img class="img-fluid" src="./assets/images/omsf.png">
                      </a>
                    </div>
                    <div class="d-flex col-xs-12 col-md-6 col-lg-3 align-items-center justify-content-center flex-column">
-                     <a href="https://www.columbia.edu/">
+                     <a class="d-inline-block h-100" href="https://www.columbia.edu/">
                        <img class="img-fluid" src="./assets/images/columbia.png">
                      </a>
                    </div>
                    <div class="d-flex col-xs-12 col-md-6 col-lg-3 align-items-center justify-content-center flex-column">
-                     <a href="https://aws.amazon.com/what-is-cloud-computing">
+                     <a class="d-inline-block h-100" href="https://aws.amazon.com/what-is-cloud-computing">
                        <img class="img-fluid" src="https://d0.awsstatic.com/logos/powered-by-aws.png" alt="Powered by AWS Cloud Computing">
                      </a>
                    </div>
@@ -272,7 +272,6 @@
                    </div>
                    <div class="d-flex col-xs-12 col-md-6 col-lg-3 align-items-center justify-content-between flex-column">
                        <img class="img-fluid" src="./assets/images/img-04.jpg"-->
-                   </div>
                </div>
            </div>
        </div>


### PR DESCRIPTION
I've added a fix to make the Supported By section responsive and to stop the images from collapsing on themselves.  I think part of this issue stems from the original design where we originally planned to include text under the logos.  There can probably be some general simplification/improvement in the CSS for some of those logo farm areas since they're just images now instead of image+text.

I've also changed the col-lg size for the "Join the Consortium" text since it was making one section smaller for certain resolutions.