### PR TITLE
adding article about new openfold members

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,11 +134,25 @@
                   </div>
               </div>
               <div class="row gx-4 gx-lg-5 d-flex justify-content-center pt-5">
+                    <div class="col-md-4 mb-5">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h2 class="card-title">OpenFold Welcomes Bayer, Dassault, CHARM Therapeutics and BaseCamp Research</h2>
+                                <p class="card-text">OpenFold, a non-profit artificial intelligence (AI) research consortium whose goal is to develop free and open source software 
+                                    tools for biology and drug discovery, today announced the addition of four new industry members: Bayer, Dassault Systèmes, CHARM Therapeutics, 
+                                    and BaseCamp Research Ltd. Read the full story in Business Wire.</p>
+                            </div>
+                            <div class="card-footer"><a class="btn text-white fold-button" href="https://www.businesswire.com/news/home/20221122005163/en/%C2%A0OpenFold-AI-Research-Consortium-Welcomes-4-New-Members-Bayer-Dassault-CHARM-Therapeutics-and-BaseCamp-Research">Read more</a></div>
+                        </div>
+                    </div>
                   <div class="col-md-4 mb-5">
                       <div class="card h-100">
                           <div class="card-body">
                               <h2 class="card-title">Announcing OpenFold</h2>
-                              <p class="card-text">A set of leading academic and industry partners are announcing the formation of OpenFold, a non-profit artificial intelligence (AI) research consortium of organizations whose goal is to develop free and open source software tools for biology and drug discovery. OpenFold is a project of the Open Molecular Software Foundation (OMSF), a non-profit organization advancing molecular sciences by building communities for open source research software development. Read the full story in Business Wire.</p>
+                              <p class="card-text">A set of leading academic and industry partners are announcing the formation of OpenFold, a non-profit artificial intelligence (AI) 
+                                research consortium of organizations whose goal is to develop free and open source software tools for biology and drug discovery. OpenFold is a project 
+                                of the Open Molecular Software Foundation (OMSF), a non-profit organization advancing molecular sciences by building communities for open source research 
+                                software development. Read the full story in Business Wire.</p>
                           </div>
                           <div class="card-footer"><a class="btn text-white fold-button" href="https://www.businesswire.com/news/home/20220628005101/en/Academic-Industry-Leaders-Form-OpenFold-AI-Research-Consortium-to-Develop-Open-Source-Software-Tools-To-Understand-Biological-Systems-and-Discover-New-Medicines">Read more</a></div>
                       </div>
@@ -147,7 +161,9 @@
                       <div class="card h-100">
                           <div class="card-body">
                               <h2 class="card-title">Interview with Gustaf Ahdritz in TechCrunch</h2>
-                              <p class="card-text">Gustaf Ahdritz is the PhD student in the <a href="https://www.aqlab.io/">Al Quraishi lab</a> at Columbia University and one of the lead developers of OpenFold. He shares his thoughts in this TechCrunch piece on the value of open source and community in science, AI models and why OpenFold came about when AlphaFold2 is already out there. </p>
+                              <p class="card-text">Gustaf Ahdritz is the PhD student in the <a href="https://www.aqlab.io/">Al Quraishi lab</a> at Columbia University and one of the lead 
+                                developers of OpenFold. He shares his thoughts in this TechCrunch piece on the value of open source and community in science, AI models and why OpenFold 
+                                came about when AlphaFold2 is already out there. </p>
                           </div>
                           <div class="card-footer"><a class="btn text-white fold-button" href="https://techcrunch.com/2022/05/19/when-big-ai-labs-refuse-to-open-source-their-models-the-community-steps-in/">Read more</a></div>
                       </div>


### PR DESCRIPTION
Adding a link to https://www.businesswire.com/news/home/20221122005163/en/%C2%A0OpenFold-AI-Research-Consortium-Welcomes-4-New-Members-Bayer-Dassault-CHARM-Therapeutics-and-BaseCamp-Research to the news section:

![Screen Shot 2022-12-09 at 9 10 42 AM](https://user-images.githubusercontent.com/455324/206721023-0844b428-c734-4cc1-b292-4b29b022e598.png)
